### PR TITLE
下書き記事の一覧と詳細を取得するAPIの追加

### DIFF
--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -1,0 +1,15 @@
+module Api::V1
+  class Articles::DraftsController < BaseApiController
+    before_action :authenticate_user!
+
+    def index
+      articles = current_user.articles.draft.order(updated_at: :desc)
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+
+    def show
+      articles = current_user.articles.draft.find(params[:id])
+      render json: articles
+    end
+  end
+end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -3,12 +3,12 @@ module Api::V1
     before_action :authenticate_user!, only: [:create, :update, :destroy]
 
     def index
-      articles = Article.order(updated_at: :desc)
+      articles = Article.published.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
     end
 
     def show
-      articles = Article.find(params[:id])
+      articles = Article.published.find(params[:id])
       render json: articles
     end
 
@@ -31,7 +31,7 @@ module Api::V1
     private
 
       def article_params
-        params.require(:article).permit(:title, :body)
+        params.require(:article).permit(:title, :body, :status)
       end
   end
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,4 +1,4 @@
 class ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :updated_at, :status
   belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,10 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }
+
+      namespace :articles do
+        resources :drafts, only: [:index, :show]
+      end
       resources :articles
     end
   end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Article, type: :model do
 
   context "statusがdraftのとき"do
     let(:article){build(:article, :draft)}
-    fit "記事が下書きで作成される" do
+    it "記事が下書きで作成される" do
       expect(article).to be_valid
       expect(article.status).to eq "draft"
     end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Articles::Drafts", type: :request do
+  describe "GET api/v1/articles/drafts" do
+    subject { get(api_v1_articles_drafts_path, headers: headers) }
+
+    context "自分で作成した下書き記事が存在するとき" do
+      let(:headers) { current_user.create_new_auth_token }
+      let(:current_user) { create(:user) }
+      let!(:article1) { create(:article, :draft, updated_at: 1.days.ago, user: current_user) }
+      let!(:article2) { create(:article, :draft, updated_at: 2.days.ago, user: current_user) }
+      let!(:article3) { create(:article, :draft, user: current_user) }
+      let!(:article4) { create(:article, :draft) }
+
+      it "下書き記事の一覧が取得できる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(response).to have_http_status(:ok)
+        expect(res.length).to eq 3
+        expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
+        expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+        expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+      end
+    end
+
+    describe "GET api/v1/articles/drafts/:id" do
+      subject { get(api_v1_articles_draft_path(article_id), headers: headers) }
+
+      context "指定したidの下書き記事が存在するとき" do
+        let(:headers) { current_user.create_new_auth_token }
+        let(:current_user) { create(:user) }
+        let(:article_id) { article.id }
+        let!(:article) { create(:article, :draft, user: current_user) }
+
+        it "その記事の詳細を表示できる" do
+          subject
+          res = JSON.parse(response.body)
+          expect(response).to have_http_status(:ok)
+          expect(res["title"]).to eq article.title
+          expect(res["body"]).to eq article.body
+          expect(res["updated_at"]).to be_present
+          expect(res["user_id"]).to eq article.user.id
+          expect(res["status"]).to eq "draft"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
・drafts_controllerの作成
・ルーティングの修正　
    index: /api/v1/articles/draft
    show: /api/v1/articles/draft/:id
上記テストの追加